### PR TITLE
Don't download a file if it already exists

### DIFF
--- a/src/download.js
+++ b/src/download.js
@@ -3,14 +3,15 @@ const fs = require("fs/promises");
 
 const downloadFile = async (url, destPath) => {
     const filename = url.split("/").pop();
-    const res = await fetch(url);
-    const buf = Buffer.from(await res.arrayBuffer());
     const destination = path.join(destPath, filename)
 
     try {
         await fs.access(destination, fs.constants.R_OK)
-    } catch (err) {
-        fs.writeFile(destination, Buffer.from(buf), err => {
+        // file exists, do nothing
+    } catch (err) { // download file
+        const res = await fetch(url);
+        const buf = Buffer.from(await res.arrayBuffer());
+        fs.writeFile(destination, buf, err => {
             if (err) return console.error(err);
         })
     }


### PR DESCRIPTION
`downloadFile` now attempts to access the file before downloading. If it exists, skip download altogether. If it doesn't already exist, fetch and write to the path on disk

Please ignore the wording in the commit message, which is the total opposite of the intentions of the commit.